### PR TITLE
Housekeeping

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,11 +4,6 @@ the requirements below.
 
 -->
 
-##### Checklist
-<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
-
-- [ ] commit message follows [commit guidelines]
-
 <!--
 Developer's Certificate of Origin 1.1
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+MIT License
+
 Copyright (c) 2020 Contributors https://github.com/nodejs/ci-config-travis/graphs/contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,8 @@
-The MIT License (MIT)
-=====================
+Copyright (c) 2020 Contributors https://github.com/nodejs/ci-config-travis/graphs/contributors
 
-Copyright (c) 2020 ci-travis-config contributors
---------------------------------------------------
-
-*ci-config-travis contributors listed at <https://github.com/nodejs/ci-config-travis/blob/master/AUTHORS>*
-                                   
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # Shared Travis Configuration Imports
 
-This repository is managed by the
-[package-maintenance team](https://github.com/nodejs/package-maintenance).
-
+This repository is managed by the [Package Maintenance Working Group](https://github.com/nodejs/package-maintenance), see [Governance](https://github.com/nodejs/package-maintenance/blob/master/Governance.md).
 


### PR DESCRIPTION
Updating according to latest discussions and docs:

- https://github.com/nodejs/package-maintenance/blob/master/Governance.md
- https://github.com/nodejs/package-maintenance/issues/368
- https://github.com/nodejs/package-maintenance/issues/348

---

- [x] LICENCE.md from the list approved by the OpenJS Foundation
- [x] CODE_OF_CONDUCT.md referencing the Node.js Code of conduct in the admin repo.
- [x] CONTRIBUTING.md which includes the current version of the Developer Certificate of Origin (DCO) used by the Node.js Project
- [x] An PR template(s) used for all Pull requests which includes the current version of the DCO used by the Node.js Project.
- [x] A README.md which includes references to the GOVERNANCE.md in the package-maintenance repository as the authoritative governance which applies to the repository.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->